### PR TITLE
Change Python version dependencies from Python>=3.10 to Python>=3.8.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # derived from Microsoft Python dev container (https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3)
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.10
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
 
 # Colab versions @2023-05-06
 # Python:                 3.10.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,19 @@ jobs:
       run: |
         pytest
 
-  # test-py308:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Set up Python 3.8
-  #     uses: actions/setup-python@v3
-  #     with:
-  #       python-version: "3.8"
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install pytest
-  #       pip install torch==2.0.0+cpu torchaudio==2.0.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
-  #   - name: Run tests
-  #     run: |
-  #       pytest
+  test-py308:
+     runs-on: ubuntu-latest
+     steps:
+     - uses: actions/checkout@v3
+     - name: Set up Python 3.8
+       uses: actions/setup-python@v3
+       with:
+         python-version: "3.8"
+     - name: Install dependencies
+       run: |
+         python -m pip install --upgrade pip
+         pip install pytest
+         pip install torch==2.0.0+cpu torchaudio==2.0.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+     - name: Run tests
+       run: |
+         pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 repository = "https://github.com/tarepan/SpeechMOS"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 ## Poetry is not good for version control of PyTorch (it has many many variants for a version, so poetry become confused)
 ## torch = "2.0.0"
 ## torchaudio = "2.0.1"

--- a/speechmos/utmos22/fairseq_alt.py
+++ b/speechmos/utmos22/fairseq_alt.py
@@ -1,7 +1,7 @@
 """W2V2 model optimized to UTMOS22 strong learner inference. Origin cloned from FairSeq under MIT license (Copyright Facebook, Inc. and its affiliates., https://github.com/facebookresearch/fairseq/blob/main/LICENSE)."""
 
 import math
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 
 import torch
 from torch import nn, Tensor

--- a/speechmos/utmos22/fairseq_alt.py
+++ b/speechmos/utmos22/fairseq_alt.py
@@ -1,6 +1,7 @@
 """W2V2 model optimized to UTMOS22 strong learner inference. Origin cloned from FairSeq under MIT license (Copyright Facebook, Inc. and its affiliates., https://github.com/facebookresearch/fairseq/blob/main/LICENSE)."""
 
 import math
+from typing import List, Tuple, Optional
 
 import torch
 from torch import nn, Tensor
@@ -43,7 +44,7 @@ class Wav2Vec2Model(nn.Module):
 class ConvFeatureExtractionModel(nn.Module):
     """Feature Encoder."""
 
-    def __init__(self, conv_layers: list[tuple[int, int, int]]):
+    def __init__(self, conv_layers: List[Tuple[int, int, int]]):
         super().__init__() # pyright: ignore [reportUnknownMemberType]
 
         def block(n_in: int, n_out: int, k: int, stride: int, is_group_norm: bool = False):
@@ -137,7 +138,7 @@ class SamePad(nn.Module):
         return x[:, :, : -1]
 
 
-def pad_to_multiple(x: Tensor | None, multiple: int, dim: int = -1, value: float = 0) -> tuple[Tensor | None, int]:
+def pad_to_multiple(x: Optional[Tensor], multiple: int, dim: int = -1, value: float = 0) -> Tuple[Optional[Tensor], int]:
     """Tail padding."""
     # Inspired from https://github.com/lucidrains/local-attention/blob/master/local_attention/local_attention.py#L41
     if x is None:
@@ -182,7 +183,7 @@ class TransformerSentenceEncoderLayer(nn.Module):
         self.self_attn_layer_norm = nn.LayerNorm(feat)
         self.final_layer_norm     = nn.LayerNorm(feat)
 
-    def forward(self, x: Tensor, self_attn_padding_mask: Tensor | None):
+    def forward(self, x: Tensor, self_attn_padding_mask: Optional[Tensor]):
         # Res[Attn-Do]-LN
         residual = x
         x = self.self_attn(x, x, x, self_attn_padding_mask)
@@ -214,7 +215,7 @@ class MultiheadAttention(nn.Module):
         self.v_proj   = nn.Linear(embed_dim, embed_dim, bias=True)
         self.out_proj = nn.Linear(embed_dim, embed_dim, bias=True)
 
-    def forward(self, query: Tensor, key: Tensor, value: Tensor, key_padding_mask: Tensor | None) -> Tensor:
+    def forward(self, query: Tensor, key: Tensor, value: Tensor, key_padding_mask: Optional[Tensor]) -> Tensor:
         """
         Args:
             query            :: (T, B, Feat)


### PR DESCRIPTION
## Summary
This PR changes the Python version dependencies from Python>=3.10 to Python>=3.8.
This may be helpful to make this toolkit widely available in other libraries (e.g. ESPnet).  
resolve #3.

## Check List
- [x] Discussed in Issue
- [x] Test passed locally

## Related Issues
- #3

## Notes
Now I am publishing the model in my forked repo. It can be run with Python 3.8 as:
```python
predictor = torch.hub.load("Takaaki-Saeki/SpeechMOS:v1.1.0", "utmos22_strong")
```
But if possible, please consider creating a new release when this PR is merged. 
